### PR TITLE
change `instituion` to `institution`

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1036,7 +1036,7 @@ Returns
     {
         "facets": {
             "levels": {
-                "instituion": 2,
+                "institution": 2,
                 "media": 3,
                 "individual": 1,
                 "internal": 2,

--- a/newslynx/constants.py
+++ b/newslynx/constants.py
@@ -63,7 +63,7 @@ IMPACT_TAG_CATEGORIES = [
 ]
 
 IMPACT_TAG_LEVELS = [
-    'instituion', 'media',
+    'institution', 'media',
     'community', 'individual', 'internal'
 ]
 


### PR DESCRIPTION
This was generating random data with a mispelling, throwing off data that expected the string `institution`
