### PR TITLE
Add missing steps to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,22 @@ createdb newslynx
     
 * modify default recipes and tags in [`example_config/defaults/recipes/`](example_config/defaults/recipes/) and [`example_config/defaults/tags/`](example_config/defaults/tags/), respectively. These tags and recipes will be created everytime a new organization is added.
 
+* make sure that redis is running in your computer, fire it if it is not
+
+```
+redis-server
+```
+
 * initialize the database:
 
 ```
 newslynx init
+```
+
+* copy default tags and recipes to `~/.newslynx/`
+
+```
+make defaults
 ```
 
 * populate with sample data


### PR DESCRIPTION
Hi @abelsonlive, 

After the SRCCON installation I added the "make defaults" and specify that redis needs to be running locally to get the newslynx core to run locally. Not sure about the redis part though it may not be needed for the installation process....but it was running when it worked for me.

Cheers

Juan
