### PR TITLE
WIP: Add Dockerfile for easy builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+#FROM debian:8
+FROM ubuntu
+
+RUN apt-get update
+RUN apt-get install -y libxml2-dev libxslt1-dev libpq-dev libffi-dev python python-dev python-distribute python-pip python-psycopg2
+RUN easy_install pip
+RUN pip install setuptools
+
+COPY . /app
+WORKDIR /app
+
+RUN python setup.py install
+
+EXPOSE 80
+EXPOSE 443
+
+#ENV DEBUG *
+ENTRYPOINT ["newslynx"]
+CMD ["runserver", "-d"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,8 +5,8 @@ newslynx:
    - redis
   ports:
    - "80"
-  # volumes:
-  #  # - ./secrets:/secrets
+  volumes:
+   - ./config:/root/.newslynx
 postgres:
   image: postgres
   environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+newslynx:
+  build: .
+  links:
+   - postgres
+   - redis
+  ports:
+   - "80"
+  # volumes:
+  #  # - ./secrets:/secrets
+postgres:
+  image: postgres
+  environment:
+    POSTGRES_DB: newslynx
+  command: postgres
+  ports:
+   - "5432"
+redis:
+  image: redis
+  ports:
+   - "3179"


### PR DESCRIPTION
Great work on the project so far, and thanks for giving everyone a tour today at SRCCON.

The README currently has some OS-independent instructions on how to run this thing, but it's hard to get those right.

The goal of this branch will be to change the instructions on how to run this in localdev to something like the following:

If you want to 
`docker run -t newslynx . && docker run newslynx`

[docker-compose](https://docs.docker.com/compose/) is young, but cool because it can also standardize running newslynx' current dependencies on postgres and redis.
`docker-compose up`

All this without mucking with the other things I have running on my mac. Yay.

Status: Work in Progress
- Dockerfile
  - [x] Choose the primary OS you want to work with. I chose ubuntu, but could change if asked.
  - [x] Installs all the right lib dependencies (e.g. python, dev bindings to lxml and such)
  - [ ] does newslynx runserver in a way that works.
    - [x] come up with a way to do the config file management steps
      
      The way I've done this so far is just to mount ./config in the container at ~/.newslynx, which is where newslynx looks for config-y stuff by default.
- docker-compose.yml
  - [ ] Use the env variables docker-compose sets about the redis and postgres ports to configure newslynx to use those dbs
- [ ] Show how to gen sample data
